### PR TITLE
linked firefox-esr to firefox

### DIFF
--- a/Vertex-Maia/apps/48x48/apps/firefox-esr.svg
+++ b/Vertex-Maia/apps/48x48/apps/firefox-esr.svg
@@ -1,0 +1,1 @@
+firefox.svg

--- a/Vertex-Maia/apps/scalable/firefox-esr.svg
+++ b/Vertex-Maia/apps/scalable/firefox-esr.svg
@@ -1,0 +1,1 @@
+firefox.svg


### PR DESCRIPTION
Just adding an icon for firefox-esr (or rather, linking it to firefox.svg). Firefox-esr looked out of place in both the panel and the menu. :smile: 
**Before**
![firefox-esr](https://cloud.githubusercontent.com/assets/11165995/23592783/84361944-01cb-11e7-8e31-4bde80cedfe9.png)
**After**
![esr-new](https://cloud.githubusercontent.com/assets/11165995/23592810/d57f7d22-01cb-11e7-9cba-bc4246b6c9ef.png)
