### PR TITLE
(FIX) Change symbolic from 22x22 to 24x24

### DIFF
--- a/Vertex-Maia/status/scalable/ac-adapter.svg
+++ b/Vertex-Maia/status/scalable/ac-adapter.svg
@@ -1,1 +1,1 @@
-../22x22/ac-adapter-symbolic.svg
+../24x24/ac-adapter-symbolic.svg


### PR DESCRIPTION
Related to the issue discussed in this pull request : https://github.com/manjaro/vertex-maia-icon-themes/pull/6